### PR TITLE
Remove ifdefs for Lanczos and Matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
+
+# Ignore generated binary
+src/RLexact

--- a/src/RLcross.C
+++ b/src/RLcross.C
@@ -43,9 +43,7 @@ double lengthofvector(komplex *);
 #ifndef M_SYM
 void ApplySmp(long long *, long long, komplex *);
 #endif
-#ifdef LANCZOS
 void CrossLanczos(long long *);
-#endif /* LANCZOS */
 
 #ifdef NEVER // doesnt work, SJ 270616
 void ApplySmpMsym(long long *, long long);
@@ -85,7 +83,6 @@ extern double *cross;
 /* Regional variables defined here */
 long long k[NSYM];
 
-#ifdef LANCZOS
 // void CrossLanczos(int symvalue[NSYM])
 void CrossLanczos(long long *symvalue) //(Note: symvalue =qvector)
 {
@@ -945,4 +942,3 @@ double lengthofvector(komplex *v)
   return length;
 }
 
-#endif /* FIND_CROSS */

--- a/src/RLcross.C
+++ b/src/RLcross.C
@@ -47,10 +47,8 @@ void CrossLanczos(long long *);
 
 #ifdef NEVER // doesnt work, SJ 270616
 void ApplySmpMsym(long long *, long long);
-#ifdef MATRIX
 void CrossMatrix();
 int sym;
-#endif /* MATRIX */
 bool NonZero(unsigned long long, long long *);
 #endif // NEVER
 
@@ -867,7 +865,6 @@ void ApplySmpMsym(long long *q, long long which_q)
 #endif // M_SYM
 
 #ifdef NEVER
-#ifdef MATRIX
 // CrossMatrix calculates now only S^zz(q) on the whole set of eigenstates
 // WARNING: all symmetries are considered to be spatial periodic translations !!
 // Written by Kim, 14.07.00
@@ -891,7 +888,6 @@ void CrossMatrix(long long symvalue[NSYM])
 
   return;
 }
-#endif /* MATRIX */
 
 bool NonZero(unsigned long long state, long long *q)
 {

--- a/src/RLexact.C
+++ b/src/RLexact.C
@@ -261,13 +261,13 @@ int main(int argc, char *argv[])
   BuildTables();
   InitSym();
 
-#ifdef M_SYM
+if(input_flags.m_sym){
   LogMessageChar("With M-symmetry \n");
-#else
+} else {
   LogMessageChar("Without M-symmetry \n");
-#endif
+}
 
-#ifdef M_SYM
+if (input_flags.m_sym){
 
   // First we must find the maximum number of unique states for any m.
   // This is always the number of uniques for the lowest absolute m-value.
@@ -342,7 +342,7 @@ int main(int argc, char *argv[])
     }
   }
 
-#else // NOT M_SYM
+}else {// NOT M_SYM
 #ifdef VERBOSE
   LogMessageChar("M_SYM not encountered \n");
   LogMessageCharInt("Unique mode is: ", unimode);
@@ -363,7 +363,7 @@ int main(int argc, char *argv[])
   {
     Nunique = FillUnique(0, 1);
   }
-#endif /* M_SYM */
+} /* M_SYM */
        // LogMessageChar("Unique mode OK \n");
        // LogMessageCharInt("Memory needed for vectors is ", (Nunique*4*sizeof(komplex)));
        // LogMessageChar("\n");

--- a/src/RLexact.h
+++ b/src/RLexact.h
@@ -10,11 +10,9 @@
 *
 ============================================
 */
-#ifndef HEADER
+#ifndef HEADER // Firstly make sure to only include all this once.
+
 #define HEADER
-
-
-
 // Struct definition for loading file
 struct FLAGS
 {
@@ -31,7 +29,6 @@ struct FLAGS
 // #define RING_EXCHANGE
 
 // Calculation of problem and output requests
-// #define LANCZOS
 // #define MATRIX    #Note FIND_CROSS currently only supports LANCZOS
 #define FIND_EIGENSTATE
 #define WRITE_ENERGIES
@@ -211,7 +208,7 @@ struct FLAGS
       new_state = SymOp(sym, new_state);     \
     }                                        \
   } /* while */
-    /*TRANSLOOP: for 1D this will be a loop over Nspins. statrs at sym=1 to avoid spin-flip/identity symmetry*/
+/*TRANSLOOP: for 1D this will be a loop over Nspins. statrs at sym=1 to avoid spin-flip/identity symmetry*/
 #define TRANSLOOP_BEGIN                     \
   T[0] = 1;                                 \
   for (sym = 1; sym < Nsym; sym++)          \

--- a/src/RLexact.h
+++ b/src/RLexact.h
@@ -1,40 +1,54 @@
-/* Include file RLexact.h - 
+/* Include file RLexact.h -
 * Main include file for diagonalization program RLexact
 * Last change: SJ 20.11.2017
 *
 ============================================
 *
 * RLexact: The exact diagonalization package
-* Christian Rischel & Kim Lefmann, 26.02.94  
+* Christian Rischel & Kim Lefmann, 26.02.94
 * Version 4.0, September 2017
-* 
+*
 ============================================
 */
+#ifndef HEADER
+#define HEADER
 
-// Physics of problem 
+
+
+// Struct definition for loading file
+struct FLAGS
+{
+  long long use_lanczos; // long long is here to allow for use of matchlines function
+  long long use_exact_matrix;
+  long long m_sym;        // M_symmetry present = 1, absent = 0
+  long long dipole;       // DLC: This is defineable, but needs testing
+  long long ring_exchang; // DLC: This is defineable, but needs testing
+};
+
+// Physics of problem
 #define M_SYM
-//#define DIPOLE     
-//#define RING_EXCHANGE
+// #define DIPOLE
+// #define RING_EXCHANGE
 
-// Calculation of problem and output requests 
-#define LANCZOS 
-//#define MATRIX    #Note FIND_CROSS currently only supports LANCZOS
+// Calculation of problem and output requests
+// #define LANCZOS
+// #define MATRIX    #Note FIND_CROSS currently only supports LANCZOS
 #define FIND_EIGENSTATE
 #define WRITE_ENERGIES
-#define FIND_CROSS //Find cross in terms of S^zz (q,w), S^xx (q,w) and S^yy(q,w) 
-//#define FIND_CROSS_PM //Find cross in S^+-(q,w) and S^-+(q,w)
-//                      instead of S^xx (q,w) and S^yy(q,w).
-//                      Requires MSYM and FIND_CROSS.
+#define FIND_CROSS // Find cross in terms of S^zz (q,w), S^xx (q,w) and S^yy(q,w)
+// #define FIND_CROSS_PM //Find cross in S^+-(q,w) and S^-+(q,w)
+//                       instead of S^xx (q,w) and S^yy(q,w).
+//                       Requires MSYM and FIND_CROSS.
 
-#define WRITE_STATES //Prints groundstate in dat-file
+#define WRITE_STATES // Prints groundstate in dat-file
 //                      and all eigenstates if MATRIX
 
-//#define FIND_MAG //Debugging required! Should only be used WITHOUT MSYM SJ 20/11/17
-//#define WRITE_MAGNETISATION //Should only be used WITHOUT MSYM,
-//                              Works only for MATRIX-mode, SJ 31/5/16
-#define MOTIVE //spin positions
+// #define FIND_MAG //Debugging required! Should only be used WITHOUT MSYM SJ 20/11/17
+// #define WRITE_MAGNETISATION //Should only be used WITHOUT MSYM,
+//                               Works only for MATRIX-mode, SJ 31/5/16
+#define MOTIVE // spin positions
 
-// Dimensions of problem 
+// Dimensions of problem
 #define NCOUP 400
 #define NCOUPSTR 10
 #define NSPINS 100
@@ -43,37 +57,34 @@
 #define NUNIQUE 4500
 #define MAXARRAYSIZE 200 // max number of entries on a given line in the input file
 #ifdef RING_EXCHANGE
-  #define NRING 100
-  #define NRINGSTR 10
+#define NRING 100
+#define NRINGSTR 10
 #endif
 
 // Highest possible state
-// #ifdef LANCZOS
-//  #define MAX_STATE ((((unsigned long) 1)<<(Nspins-1)) -1) 
+//  #define MAX_STATE ((((unsigned long) 1)<<(Nspins-1)) -1)
 // #else
-  #define MAX_STATE ((unsigned long long)1<<(Nspins)) 
+#define MAX_STATE ((unsigned long long)1 << (Nspins))
 // #endif
 
 // Set up size of buffer for sparse matrix read/write
 #ifdef MATRIX
-  #define BUFFERSIZE BUFSIZ
+#define BUFFERSIZE BUFSIZ
 #else
-  #define BUFFERSIZE 4194304
+#define BUFFERSIZE 4194304
 #endif
- 
+
 #define USE_COMPLEX
 
-#ifdef LANCZOS
-// Generated vectors with squared lengths below the following 
+// Generated vectors with squared lengths below the following
 // cutoff are considered to be zero in Lanczos calculation because of numerical precision.
 #define ZERO_VEC_LENGTH 1e-9
-#define SHORT_VEC_LENGTH (double) 1/NUNIQUE
+#define SHORT_VEC_LENGTH (double)1 / NUNIQUE
 #define MAX_LANCZOS 600
-#endif  // LANCZOS 
-#define right(i) (((i&1)<<(Nspins-1)) + (i>>1))
-#define inverse(i) (i^(MAX_STATE-1))
+#define right(i) (((i & 1) << (Nspins - 1)) + (i >> 1))
+#define inverse(i) (i ^ (MAX_STATE - 1))
 
-// Symmetry related definitions 
+// Symmetry related definitions
 #define MASK_L1 0x77777777
 #define MASK_L2 0x88888888
 #define MASK_L3 0xF000F000
@@ -82,77 +93,77 @@
 #define MASK_P2 0xFFFF0000
 
 // Hard coded symmetry flags
-#define SPIN_FLIP    0
-#define FCC32Tx      1
-#define FCC32Ty      2
-#define FCC32Tz      3
-#define FCC32MIRROR  4
-#define FCC32R2      5
-#define FCC32R4      6
-#define FCC32R3      7
-#define IDENTITY     9
-#define LINEAR_T    10
+#define SPIN_FLIP 0
+#define FCC32Tx 1
+#define FCC32Ty 2
+#define FCC32Tz 3
+#define FCC32MIRROR 4
+#define FCC32R2 5
+#define FCC32R4 6
+#define FCC32R3 7
+#define IDENTITY 9
+#define LINEAR_T 10
 
-#define SYMNUM(i,j) ( (long long) (log( (double)SymOp( (long long)i,((unsigned long long)1)<<j)+1E-6) / log((double)2) )) 
+#define SYMNUM(i, j) ((long long)(log((double)SymOp((long long)i, ((unsigned long long)1) << j) + 1E-6) / log((double)2)))
 
-// Deal with complex numbers 
+// Deal with complex numbers
 #ifdef USE_COMPLEX
-//typedef std::complex<double> komplex;
+// typedef std::complex<double> komplex;
 #define komplex std::complex<double>
 //  #define komplex _Complex double
 //  #define komplex std::complex<double>;
-  #define kvector cvector
-  #define freekvector freecvector
-  #define kmatrix cmatrix
-  #define freekmatrix freecmatrix
-  #define I komplex (0.0, 1.0) //_Complex_I
-  #define zero komplex (0.0, 0.0)
-  #define one komplex (1.0, 0.0)
-  #define Arg(a) (a==zero ? 0.0 : arg(a))
-  #define arg(a) atan2(imag(a),real(a))
-  #define abs(a) sqrt(real(a)*real(a) + imag(a)*imag(a))
-  #define sqrabs(a) (real(a)*real(a) + imag(a)*imag(a))
-  #define eksp(a) exp(real(a))*(cos(imag(a))+I*sin(imag(a))) 
-  #define conj(a)  (real(a)-I*imag(a))
-  #define skrt(a) (sqrt(abs(a))*(cos(Arg(a)/2.0)+I*sin(Arg(a)/2.0) ) )
-//#define skrt(a) (sqrt(real(a))*(cos(Arg(a)/2.0)+I*sin(Arg(a)/2.0) ) )
+#define kvector cvector
+#define freekvector freecvector
+#define kmatrix cmatrix
+#define freekmatrix freecmatrix
+#define I komplex(0.0, 1.0) //_Complex_I
+#define zero komplex(0.0, 0.0)
+#define one komplex(1.0, 0.0)
+#define Arg(a) (a == zero ? 0.0 : arg(a))
+#define arg(a) atan2(imag(a), real(a))
+#define abs(a) sqrt(real(a) * real(a) + imag(a) * imag(a))
+#define sqrabs(a) (real(a) * real(a) + imag(a) * imag(a))
+#define eksp(a) exp(real(a)) * (cos(imag(a)) + I * sin(imag(a)))
+#define conj(a) (real(a) - I * imag(a))
+#define skrt(a) (sqrt(abs(a)) * (cos(Arg(a) / 2.0) + I * sin(Arg(a) / 2.0)))
+// #define skrt(a) (sqrt(real(a))*(cos(Arg(a)/2.0)+I*sin(Arg(a)/2.0) ) )
 
 #else
-  #define komplex double
-  #define skrt(a) sqrt(a)
-  #define real(a) (a)
-  #define imag(a) 0.0
-  #define conj(a) (a)
-  #define abs(a) fabs(a)
-  #define eksp(a) exp(a)
-  #define Arg(a) 0.0
-  #define I 0.0
-  #define zero 0.0
-  #define sqrabs(a) a*a
-  #define kvector dvector
-  #define freekvector freedvector
-  #define kmatrix dmatrix
-  #define freekmatrix freedmatrix
+#define komplex double
+#define skrt(a) sqrt(a)
+#define real(a) (a)
+#define imag(a) 0.0
+#define conj(a) (a)
+#define abs(a) fabs(a)
+#define eksp(a) exp(a)
+#define Arg(a) 0.0
+#define I 0.0
+#define zero 0.0
+#define sqrabs(a) a *a
+#define kvector dvector
+#define freekvector freedvector
+#define kmatrix dmatrix
+#define freekmatrix freedmatrix
 #endif
 
-// Various definitions 
-#define SPIN_0_UP ((unsigned long long) 1)
-#define SQR(a) ((a)*(a))
-#define RANDOM ( (double) 2*rand()/RAND_MAX - 1 )
+// Various definitions
+#define SPIN_0_UP ((unsigned long long)1)
+#define SQR(a) ((a) * (a))
+#define RANDOM ((double)2 * rand() / RAND_MAX - 1)
 #define PI 3.14159265358979323846
 #define LARGE_NUMBER 9.999E+99
 #define SMALL_NUMBER 1E-6
 #define float double
 
 /* Output definitions */
-#define CSVOUT //output data to s** as comma separated values
+#define CSVOUT // output data to s** as comma separated values
 #define FILEEND ".dat"
 #define LOGFILEEND ".log"
-#define SZZEND ".szz" //only used of FIND_CROSS
-#define SXXEND ".sxx" //only used of FIND_CROSS
-#define SYYEND ".syy" //only used of FIND_CROSS
-#define SPMEND ".spm" //only used of FIND_CROSS and FIND_CROSS_PM
-#define SMPEND ".smp" //only used of FIND_CROSS and FIND_CROSS_PM
+#define SZZEND ".szz" // only used of FIND_CROSS
+#define SXXEND ".sxx" // only used of FIND_CROSS
+#define SYYEND ".syy" // only used of FIND_CROSS
+#define SPMEND ".spm" // only used of FIND_CROSS and FIND_CROSS_PM
+#define SMPEND ".smp" // only used of FIND_CROSS and FIND_CROSS_PM
 
 #define MATRIXFILENAME "SqMat"
 #define COEND ".gs"
@@ -160,144 +171,166 @@
 #define UNIEND ".un"
 #define UNIOBSEND ".uno"
 
-// Flags 
+// Flags
 #define START 1
 #define STOP 0
 #define X 0
 #define Y 1
 #define Z 2
-//#define REAL 0
-//#define IMAG 1 //Not used and clashed with OpenMPI
+// #define REAL 0
+// #define IMAG 1 //Not used and clashed with OpenMPI
 #define NORMAL 0
 #define RECONSTRUCT 1
 #define CROSS 2
 #define SZZ 0
 #define SPM 1
 #define SMP 2
-//parallelization flags
-#define MODEN 0 //Normal mode
-#define MODEW 1 //Write Hamiltonian to file
-#define MODEGS 2 //Groundstate mode
-#define MODERC 3//Reconstruct mode
-#define MODEQ 4 //Cross section mode
-#define UNIMODEN 0 //Normal mode
-#define UNIMODEW 1 //Write unique
-#define UNIMODER 2 //Read unique
+// parallelization flags
+#define MODEN 0    // Normal mode
+#define MODEW 1    // Write Hamiltonian to file
+#define MODEGS 2   // Groundstate mode
+#define MODERC 3   // Reconstruct mode
+#define MODEQ 4    // Cross section mode
+#define UNIMODEN 0 // Normal mode
+#define UNIMODEW 1 // Write unique
+#define UNIMODER 2 // Read unique
 
-// Program pieces 
-#define TLOOP_BEGIN for(sym=0;sym<Nsym;sym++) T[sym]=0;       \
-                    sym=0, new_state=state;                         \
-                    while(T[Nsym-1]<Nsymvalue[Nsym-1]) {
-#define TLOOP_END   new_state=SymOp(0,new_state);                         \
-		    for (sym=0; ++T[sym]==Nsymvalue[sym]; )   \
-	              if (sym<Nsym-1) { T[sym++]=0;           \
-                                new_state=SymOp(sym,new_state);}}      /* while */
- /*TRANSLOOP: for 1D this will be a loop over Nspins. statrs at sym=1 to avoid spin-flip/identity symmetry*/
-#define TRANSLOOP_BEGIN T[0]=1;     \
-                    for(sym=1;sym<Nsym;sym++) T[sym]=0;       \
-                    sym=1, new_state=state;                         \
-                    while(T[Nsym-1]<Nsymvalue[Nsym-1]) {
-#define TRANSLOOP_END   new_state=SymOp(1,new_state);                         \
-		    for (sym=1; ++T[sym]==Nsymvalue[sym]; )   \
-	              if (sym<Nsym-1) { T[sym++]=0;           \
-                                new_state=SymOp(sym,new_state);}}      /* while */
+// Program pieces
+#define TLOOP_BEGIN                         \
+  for (sym = 0; sym < Nsym; sym++)          \
+    T[sym] = 0;                             \
+  sym = 0, new_state = state;               \
+  while (T[Nsym - 1] < Nsymvalue[Nsym - 1]) \
+  {
+#define TLOOP_END                            \
+  new_state = SymOp(0, new_state);           \
+  for (sym = 0; ++T[sym] == Nsymvalue[sym];) \
+    if (sym < Nsym - 1)                      \
+    {                                        \
+      T[sym++] = 0;                          \
+      new_state = SymOp(sym, new_state);     \
+    }                                        \
+  } /* while */
+    /*TRANSLOOP: for 1D this will be a loop over Nspins. statrs at sym=1 to avoid spin-flip/identity symmetry*/
+#define TRANSLOOP_BEGIN                     \
+  T[0] = 1;                                 \
+  for (sym = 1; sym < Nsym; sym++)          \
+    T[sym] = 0;                             \
+  sym = 1, new_state = state;               \
+  while (T[Nsym - 1] < Nsymvalue[Nsym - 1]) \
+  {
+#define TRANSLOOP_END                        \
+  new_state = SymOp(1, new_state);           \
+  for (sym = 1; ++T[sym] == Nsymvalue[sym];) \
+    if (sym < Nsym - 1)                      \
+    {                                        \
+      T[sym++] = 0;                          \
+      new_state = SymOp(sym, new_state);     \
+    }                                        \
+  } /* while */
 
-#define QLOOP_BEGIN for(sym=0;sym<Nsym;sym++) q[sym]=0;       \
-                    sym=0;                                    \
-                    while(q[Nsym-1]<Nsymvalue[Nsym-1]) {
-#define QLOOP_END   for (sym=0; ++q[sym]==Nsymvalue[sym]; ) { \
-	              if (sym<Nsym-1) q[sym++]=0; } }  /* while */
+#define QLOOP_BEGIN                         \
+  for (sym = 0; sym < Nsym; sym++)          \
+    q[sym] = 0;                             \
+  sym = 0;                                  \
+  while (q[Nsym - 1] < Nsymvalue[Nsym - 1]) \
+  {
+#define QLOOP_END                            \
+  for (sym = 0; ++q[sym] == Nsymvalue[sym];) \
+  {                                          \
+    if (sym < Nsym - 1)                      \
+      q[sym++] = 0;                          \
+  }                                          \
+  } /* while */
 
 // General debugging requests from RLexact.C
 
-//#define VERBOSE
-//#define VERBOSE_TIME_LV1
-//#define VERBOSE_TIME_LV2
+// #define VERBOSE
+// #define VERBOSE_TIME_LV1
+// #define VERBOSE_TIME_LV2
 
+// Debugging output requests from RLexact.c
+// #define TEST_GS_SEARCH
+// #define TEST_ALLOCATE
+// #define MAIN_LOOP_MESSAGES
 
-// Debugging output requests from RLexact.c 
-//#define TEST_GS_SEARCH 
-//#define TEST_ALLOCATE
-//#define MAIN_LOOP_MESSAGES
-
-// Debugging output requests from RLhamil.c 
-//#define TEST_HAMILTON  /*this tests an old version of Hamilton, no longer in use*/
-//#define TEST_MAT_ELEM 
-//#define TEST_HAM2  
-//#define TEST_HAMZEE
-//#define TEST_FILLHAM 
+// Debugging output requests from RLhamil.c
+// #define TEST_HAMILTON  /*this tests an old version of Hamilton, no longer in use*/
+// #define TEST_MAT_ELEM
+// #define TEST_HAM2
+// #define TEST_HAMZEE
+// #define TEST_FILLHAM
 
 // Debugging output requests from RLsparse.C
-//#define TEST_MAKESPARSE
-//#define TEST_APPLYSPARSE
-//#define TEST_APPLYSPARSE_READ
-//#define TEST_APPLYSPARSE_DEEP
-//#define DEBUG_APPLYSPARSE
-//#define TEST_HAM4
+// #define TEST_MAKESPARSE
+// #define TEST_APPLYSPARSE
+// #define TEST_APPLYSPARSE_READ
+// #define TEST_APPLYSPARSE_DEEP
+// #define DEBUG_APPLYSPARSE
+// #define TEST_HAM4
 
+// Debugging output requests from RLmatrix.c
+// #define MATRIX_MESSAGES
+// #define TEST_EIG
+// #define TEST_EVEC
+// #define TEST_MATRIXMAG
+// #define TEST_CALC_M
+// #define TEST_CALC_SZZQ
 
-// Debugging output requests from RLmatrix.c 
-//#define MATRIX_MESSAGES 
-//#define TEST_EIG 
-//#define TEST_EVEC
-//#define TEST_MATRIXMAG  
-//#define TEST_CALC_M 
-//#define TEST_CALC_SZZQ 
+// Debugging output requests from RLlanczos.c
+// #define TEST_SEED
+// #define TEST_EIGENVECTORS
+// #define TEST_FINDGROUND
+// #define TEST_STATES
+// #define TEST_ENERGIES
+// #define TEST_LANCZOS_VECTOR
+// #define LANCZOS_MESSAGES
+// #define VERBOSE_LANCZOS
+// #define TEST_FINDMAG
+// #define DEBUG_SEED // WARNING: May cause premature stopping of lanczos algorithm
+// #define DEBUG_LANCSTEP
+// #define TEST_LANCCROSS
 
-// Debugging output requests from RLlanczos.c 
-//#define TEST_SEED 
-//#define TEST_EIGENVECTORS
-//#define TEST_FINDGROUND
-//#define TEST_STATES 
-//#define TEST_ENERGIES
-//#define TEST_LANCZOS_VECTOR
-//#define LANCZOS_MESSAGES
-//#define VERBOSE_LANCZOS
-//#define TEST_FINDMAG
-//#define DEBUG_SEED // WARNING: May cause premature stopping of lanczos algorithm
-//#define DEBUG_LANCSTEP
-//#define TEST_LANCCROSS
+// Debugging output requests from RLtables.c
+// #define TEST_TABLES
+// #define TEST_INVERTMATRIX
+// #define TEST_OCC
+// #define TEST_ISUNIQUE
+// #define TEST_FINDUNIQUE
+// #define TEST_FINDUNIQUE_DETAIL
+// #define TEST_FILLUNIQUE
+// #define TEST_READUNIQUE
+// #define TEST_FILLUNIQUE_LIST
+// #define TEST_FILLUNIQUEOBSERVABLES
+// #define TEST_COUNT
+// #define TEST_LOOKUP
+// #define TEST_CHECKPHASE
 
-// Debugging output requests from RLtables.c 
-//#define TEST_TABLES    
-//#define TEST_INVERTMATRIX
-//#define TEST_OCC
-//#define TEST_ISUNIQUE
-//#define TEST_FINDUNIQUE  
-//#define TEST_FINDUNIQUE_DETAIL
-//#define TEST_FILLUNIQUE 
-//#define TEST_READUNIQUE 
-//#define TEST_FILLUNIQUE_LIST
-//#define TEST_FILLUNIQUEOBSERVABLES
-//#define TEST_COUNT 
-//#define TEST_LOOKUP   
-//#define TEST_CHECKPHASE 
-
-// Debugging output requests from RLsymm.c 
-//#define TEST_SYM
-//#define TEST_SYMCOUPLING   
+// Debugging output requests from RLsymm.c
+// #define TEST_SYM
+// #define TEST_SYMCOUPLING
 
 // Debugging output requests from RLio.c and RLutil.c
-//#define TEST_WRITECROSS
-//#define TEST_SPINFLIP
-//#define TEST_INPUT
-//#define TEST_ROTATION
+// #define TEST_WRITECROSS
+// #define TEST_SPINFLIP
+// #define TEST_INPUT
+// #define TEST_ROTATION
 
-// Debugging output requests from RLcross.c 
-//#define PRINT_STATES DOESN'T EXIST ANYMORE
-//#define PRINT_ENERGIES  DOESN'T EXIST ANYMORE
-//#define TEST_APPLYSMP
-//#define TEST_APPLYSZQ 
-//#define TEST_CROSS
+// Debugging output requests from RLcross.c
+// #define PRINT_STATES DOESN'T EXIST ANYMORE
+// #define PRINT_ENERGIES  DOESN'T EXIST ANYMORE
+// #define TEST_APPLYSMP
+// #define TEST_APPLYSZQ
+// #define TEST_CROSS
 
-
-// Debugging output requests from Diagonal.C 
-//#define TEST_DIAGONALIZE 
+// Debugging output requests from Diagonal.C
+// #define TEST_DIAGONALIZE
 
 // Debugging output requests from regcc.cpp
-//#define TEST_MULTIMATCH
-//#define TEST_FILEREAD
+// #define TEST_MULTIMATCH
+// #define TEST_FILEREAD
 //
 
 // Found in RLexact.h Previously named MEMORY_DEBUG, but not called anywhere.
-//#define TEST_MEMORY
+// #define TEST_MEMORY
+#endif

--- a/src/RLexact.h
+++ b/src/RLexact.h
@@ -29,7 +29,6 @@ struct FLAGS
 // #define RING_EXCHANGE
 
 // Calculation of problem and output requests
-// #define MATRIX    #Note FIND_CROSS currently only supports LANCZOS
 #define FIND_EIGENSTATE
 #define WRITE_ENERGIES
 #define FIND_CROSS // Find cross in terms of S^zz (q,w), S^xx (q,w) and S^yy(q,w)
@@ -65,11 +64,7 @@ struct FLAGS
 // #endif
 
 // Set up size of buffer for sparse matrix read/write
-#ifdef MATRIX
-#define BUFFERSIZE BUFSIZ
-#else
 #define BUFFERSIZE 4194304
-#endif
 
 #define USE_COMPLEX
 

--- a/src/RLio.C
+++ b/src/RLio.C
@@ -208,10 +208,10 @@ long long intro(struct FLAGS *input_flags)
     if (input_flags->use_exact_matrix)
       OutMessageChar("Using Matrix");
     else if (input_flags->use_lanczos)
-      OutMessageChar("Using Lanczos ");
-    OutMessageCharInt(" diagonalization. BUFFERSIZE =", BUFFERSIZE);
+      OutMessageChar("Using Lanczos");
+    OutMessageCharInt("diagonalization. BUFFERSIZE =", BUFFERSIZE);
 #ifdef M_SYM
-    OutMessageChar(" M-symmetry present. \n");
+    OutMessageChar("M-symmetry present. \n");
 #else
     OutMessageChar(" M-symmetry absent. \n");
 #endif /* M_SYM */
@@ -383,6 +383,7 @@ void ReadInputFlags(char *filename, struct FLAGS *input_flags)
   }
   filereader(filename, filedata, filesize); // the entire file is now in filedata
   input_flags->use_lanczos = 1;             // Using lanczos is default.
+  input_flags->use_exact_matrix = 0;
   matchlines_wrapper(filedata, "Use Exact Matrix", &input_flags->use_exact_matrix, true);
   matchlines_wrapper(filedata, "Use Lanczos", &input_flags->use_lanczos, true);
 }

--- a/src/RLio.C
+++ b/src/RLio.C
@@ -53,7 +53,7 @@ void LogMessageChar3Vector(const char *, double, double, double);
 void WriteState(const char *, komplex *);
 void WriteStates(komplex **);
 void WritehmQ(long long *);
-void WriteResults(long long);
+void WriteResults(long long, struct FLAGS *);
 void WriteCross(long long, long long *, long long);
 void WriteGSEnergy(komplex);
 void WriteEnergy(double);
@@ -1222,7 +1222,7 @@ void WritehmQ(long long *q)
   return;
 }
 
-void WriteResults(long long N)
+void WriteResults(long long N, struct FLAGS *input_flags)
 {
   /* Output the energies and other observables of the eigenstates */
   long long i, q;
@@ -1249,9 +1249,10 @@ void WriteResults(long long N)
       magnetisation[i] = 0;
     }
 #ifdef WRITE_MAGNETISATION
-#ifdef MATRIX // only meaningful for matrix-calculations
-    fprintf(outfile, ", mag_z= %9.6g ", magnetisation[i]);
-#endif // MATRIX
+    if (input_flags->use_exact_matrix)
+    {
+      fprintf(outfile, ", mag_z= %9.6g ", magnetisation[i]);
+    }
 #endif // WRITE_MAGNETISATION
 #endif /* FIND_MAG */
 

--- a/src/RLlancz.C
+++ b/src/RLlancz.C
@@ -25,7 +25,6 @@
 #include <nr.h>
 #include <cnr.h>
 
-#ifdef LANCZOS
 /* Functions defined in this file */
 double LowestLanczos(long long *, komplex *, long long *, long long);
 long long CrossLanczos(long long *);
@@ -720,5 +719,3 @@ double Normalize(komplex *vector1)
 
   return (lg);
 }
-
-#endif /* LANCZOS */

--- a/src/RLmatrix.C
+++ b/src/RLmatrix.C
@@ -33,7 +33,7 @@ double CalculateM(komplex *);
 #endif /* FIND_MAG */
 
 /* Functions declared elsewhere */
-void BuildCycle(long long *);
+void BuildCycle(long long *, struct FLAGS *);
 extern void WriteEnergy(double);
 // extern void FillHamilton(long long *, long long *, komplex**); OLD version
 extern void FillHamilSparse(komplex **, long long *k);
@@ -77,7 +77,7 @@ unsigned long long i_min;
 k[] and given h/m and finds the ground state.
 The routine returns the energy of the ground state,
 and evec is the ground state vector */
-double Matrix_gs(komplex **hamil, long long *uniqk, long long k[NSYM], komplex *evec)
+double Matrix_gs(komplex **hamil, long long *uniqk, long long k[NSYM], komplex *evec, struct FLAGS *input_flags)
 {
   time_t time_single;
   double emin;
@@ -90,7 +90,7 @@ double Matrix_gs(komplex **hamil, long long *uniqk, long long k[NSYM], komplex *
 #ifdef VERBOSE_TIME_LV1
   time_stamp(&time_single, START, "\n timer of intiallizing and filling matrix");
 #endif /* VERBOSE_TIME_LV1*/
-  BuildCycle(k);
+  BuildCycle(k, input_flags);
 #ifdef MATRIX_MESSAGES
   LogMessageCharInt(" Nuniq_k: ", Nuniq_k);
   hamil[1][1] = zero;

--- a/src/RLtables.C
+++ b/src/RLtables.C
@@ -602,10 +602,11 @@ void BuildCycle(long long q[NSYM], struct FLAGS *input_flags)
       }
     }
 
-#ifdef MATRIX
-    if (Nocc[j] > 0)
-      uniq_k[uniq_count++] = j;
-#endif // MATRIX
+    if (input_flags->use_exact_matrix)
+    {
+      if (Nocc[j] > 0)
+        uniq_k[uniq_count++] = j;
+    }
 
 #ifdef TEST_OCC
     LogMessageCharInt(" Unique", j);
@@ -618,9 +619,10 @@ void BuildCycle(long long q[NSYM], struct FLAGS *input_flags)
 #endif /* TEST_OCC */
   }
 
-#ifdef MATRIX
-  Nuniq_k = uniq_count;
-#endif
+  if (input_flags->use_exact_matrix)
+  {
+    Nuniq_k = uniq_count;
+  }
 
 #ifdef TEST_OCC
   LogMessageChar(" Exit BuildCycle \n");

--- a/src/RLtables.C
+++ b/src/RLtables.C
@@ -33,7 +33,7 @@ unsigned long long FillUnique(long long, int);
 // Fill the table of unique states
 void FillUniqueObservables();
 // Write diagonal values of the unique states to file
-void BuildCycle(long long *);
+void BuildCycle(long long *, struct FLAGS *);
 // Make table of number of occurences of a particular unique in a particular symmetry cycle
 unsigned long long FindUnique(unsigned long long, int *);
 // Find the unique corresponding to a particular state
@@ -530,7 +530,7 @@ void FillUniqueObservables()
 }
 
 /* Build table of occurencies in a full cycle, for one q-value */
-void BuildCycle(long long q[NSYM])
+void BuildCycle(long long q[NSYM], struct FLAGS *input_flags)
 {
   long long sym, s, j, count, tot_count, phi, uniq_count = 0;
   int T[NSYM];
@@ -589,17 +589,18 @@ void BuildCycle(long long q[NSYM])
     Nocc[j] = (long long)floor(p_r + SMALL_NUMBER); // round off phase sum to a real integer
 
     // save the Nocc in q=0 for use in cross section calcs with Lanczos
-#ifdef LANCZOS
-    qlength = 0;
-    for (int k = 1; k < Nsym; k++)
+    if (input_flags->use_lanczos)
     {
-      qlength += q[k] * q[k];
+      qlength = 0;
+      for (int k = 1; k < Nsym; k++)
+      {
+        qlength += q[k] * q[k];
+      }
+      if (qlength == 0)
+      {
+        Nocc_0[j] = Nocc[j];
+      }
     }
-    if (qlength == 0)
-    {
-      Nocc_0[j] = Nocc[j];
-    }
-#endif
 
 #ifdef MATRIX
     if (Nocc[j] > 0)

--- a/src/test.h
+++ b/src/test.h
@@ -1,0 +1,29 @@
+Use Lanczos 2
+Ritz_conv 0.001
+Zero_vec_length 0.001
+Mode 0
+Unimode 0
+Mode 0
+M start 0
+M end 0
+Number of spins 2
+Number of Couplings 2
+Number of Coupling strengths 1
+Number of Hardcoded symmetries 0
+Number of custom symmetries 2
+Number of chosen GS q-values 0
+Number of Dimensions 1
+Translation vector 1
+Translation indices 1 0 0
+Number of spins in unit cell 1
+Relative position 0 0 0
+Qmax translation 1 1 1
+Spin position 0
+Spin position 1
+Construct symmetries 0
+Hardcoded symmetries 0
+Custom symmetry 0 1
+Custom symmetry 1 0
+Coupling strength vector -1 -1 0
+Coupling vector 0 1 0
+Coupling vector 1 0 0


### PR DESCRIPTION
Begin work on removing Lanczos by implementing a flag struct to carry over flags chosen in the configuration file instead of in the RLexact header file.